### PR TITLE
Fix d3.select picking up first inline SVG on the page rather than the .Edges SVG

### DIFF
--- a/src/lib/Containers/GraphView/index.svelte
+++ b/src/lib/Containers/GraphView/index.svelte
@@ -25,7 +25,7 @@
   const dotSize = 10;
 
   onMount(() => {
-    d3.select('svg').call(d3Zoom);
+    d3.select('.Edges').call(d3Zoom);
     d3.select('.Nodes').call(d3Zoom);
   });
 
@@ -49,7 +49,7 @@
         .attr('opacity', Math.min(e.transform.k, 1));
     }
     // transform 'g' SVG elements (edge, edge text, edge anchor)
-    d3.select('svg g').attr('transform', e.transform);
+    d3.select('.Edges g').attr('transform', e.transform);
     // transform div elements (nodes)
     let transform = d3.zoomTransform(this);
     // selects and transforms all node divs from class 'Node'


### PR DESCRIPTION
Hi, I saw Svelvet in a LinkedIn post and was playing around.

When I pan and zoom, Svelvet keeps panning and zooming another inline SVG on my page and not the Svelvet edges SVG, i.e. the one with the `.Edges` class.

To replicate the issue add an inline SVG (with a `<g>` element) to a test page before a Svelvet diagram.