### PR TITLE
feat: add border radius customization

### DIFF
--- a/src/lib/Nodes/index.svelte
+++ b/src/lib/Nodes/index.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import BaseEdge from '$lib/Edges/BaseEdge.svelte';
-
   import { onMouseMove, nodeSelected } from '$lib/stores/store';
   import type { Node } from '$lib/types/types';
 
@@ -33,6 +31,7 @@
     height: {node.height}px; 
     background-color: {node.bgColor}; 
     border-color: {node.borderColor}; 
+    border-radius: {node.borderRadius}px;
     color: {node.textColor};"
 >
   <slot />

--- a/src/lib/types/types.ts
+++ b/src/lib/types/types.ts
@@ -11,6 +11,7 @@ export interface Node<T = any> {
   bgColor?: string;
   fontSize?: number;
   borderColor?: string;
+  borderRadius?: number;
   textColor?: string;
 }
 

--- a/src/routes/docs/custom-nodes.svelte
+++ b/src/routes/docs/custom-nodes.svelte
@@ -7,6 +7,7 @@
     ['height', '(required) number'],
     ['bgColor', 'string of color name or hexcode'],
     ['borderColor', 'string of color name or hexcode'],
+    ['borderRadius', 'number'],
     ['textColor', 'string of color name or hexcode']
   ];
 </script>
@@ -23,12 +24,11 @@
 </p>
 <p class="text-gray-600 mt-2">
   Current customizations include node
-  <code class="code">position</code>,
-  <code class="code">width</code>,
-  <code class="code">height</code>,
-  <code class="code">bgColor</code>,
-  <code class="code">borderColor</code>, and
-  <code class="code">textColor</code>.
+  {#each nodeProps as [key], i}
+    <code class="code">{key}</code>{#if i < nodeProps.length - 2}{', '}
+    {:else if i === nodeProps.length - 2}{', and '}
+    {:else}.{/if}
+  {/each}
 </p>
 
 <h3 class="text-xl font-semibold mt-12">Node Properties</h3>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -61,10 +61,11 @@
       id: 6,
       type: 'output',
       position: { x: 72.5, y: 360 },
-      data: { label: 'Important Square!' },
+      data: { label: 'Important Circle!' },
       width: 80,
       height: 80,
       borderColor: '#FF4121',
+      borderRadius: 40,
       bgColor: 'white',
       textColor: '#FF4121'
     }


### PR DESCRIPTION
hi, love the library & excited to use it! one minor feature request: could `border-radius` be a customizable property?

I added it alongside `border-color`, this moves in the direction of custom shapes & enables circles (and non-rounded squares). also added to the index example for visibility when reviewing, can remove if this is mergeable 🙂