### PR TITLE
Group tests

### DIFF
--- a/src/routes/group-test/+page.svelte
+++ b/src/routes/group-test/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { Svelvet, Group, Node } from '$lib';
+</script>
+
+<Svelvet minimap controls theme={'dark'} width={800} height={850}>
+	<Group position={{ x: 200, y: 200 }} width={400} height={300} groupName="nodes">
+		<Node position={{ x: 100, y: 100 }} label="Inside" dimensions={{ width: 100, height: 100 }} />
+	</Group>
+	<Node position={{ x: 650, y: 350 }} label="Right" dimensions={{ width: 100, height: 100 }} />
+	<Node position={{ x: 50, y: 350 }} label="Left" dimensions={{ width: 100, height: 100 }} />
+	<Node position={{ x: 350, y: 50 }} label="Top" dimensions={{ width: 100, height: 100 }} />
+	<Node position={{ x: 350, y: 650 }} label="Bottom" dimensions={{ width: 100, height: 100 }} />
+</Svelvet>

--- a/tests/e2e-tests/group/test.ts
+++ b/tests/e2e-tests/group/test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+const testRoute = '/group-test';
+
+test('group functionality', async ({ page }) => {
+	await page.goto(testRoute);
+
+	// wrapping Node in a group
+	// Node is contained to the size of the group (appears 10px padding)
+	const insideNode = await page.locator('#N-1');
+	// right
+	await insideNode.dragTo(page.locator('#N-2'));
+	await expect(insideNode).toHaveCSS('left', '490px');
+	// left
+	await insideNode.dragTo(page.locator('#N-3'));
+	await expect(insideNode).toHaveCSS('left', '210px');
+	// top
+	await insideNode.dragTo(page.locator('#N-4'));
+	await expect(insideNode).toHaveCSS('top', '210px');
+	// bottom
+	await insideNode.dragTo(page.locator('#N-5'));
+	await expect(insideNode).toHaveCSS('top', '390px');
+
+	// Moving the group moves the nodes inside
+	await page.mouse.move(250, 250);
+	await page.mouse.down();
+	await page.mouse.move(250, 200);
+	await page.mouse.up();
+	await expect(insideNode).not.toHaveCSS('top', '390px');
+
+	// creates a group with command+shift+drag
+	await page.mouse.move(300, 600);
+	await page.keyboard.down('Shift');
+	await page.keyboard.down('Meta');
+	await page.mouse.down();
+	await page.mouse.move(500, 800);
+	await page.mouse.up();
+	const groups = await page.$$('.bounding-box-border');
+	await expect(groups).toHaveLength(2);
+
+	// nodes are contained by a dynamically created group
+	const insideNode2 = await page.locator('#N-5');
+	await insideNode2.dragTo(page.locator('#N-4'));
+	await expect(insideNode2).toHaveCSS('top', '640px'); // not sure why this is not 610px, however it did move up since start is 650px
+});


### PR DESCRIPTION
Adds testing for the Group component. This includes testing that nodes are restricted to inside the group border, nodes move with the group border, as well as checking that groups created dynamically function as intended.