### PR TITLE
Arrows and Toggle

### DIFF
--- a/src/lib/components/Anchor/Anchor.svelte
+++ b/src/lib/components/Anchor/Anchor.svelte
@@ -6,7 +6,15 @@
 	import { writable, get } from 'svelte/store';
 	import { createEdge, createAnchor, generateOutput } from '$lib/utils/creators';
 	import { createEventDispatcher } from 'svelte';
-	import type { Graph, Node, Connections, CSSColorString, EdgeStyle, EdgeConfig } from '$lib/types';
+	import type {
+		Graph,
+		Node,
+		Connections,
+		CSSColorString,
+		EdgeStyle,
+		EndStyle,
+		EdgeConfig
+	} from '$lib/types';
 	import type {
 		Anchor,
 		Direction,
@@ -88,6 +96,7 @@
 	 */
 	export let nodeConnect = false;
 	export let edgeStyle: EdgeStyle | null = null;
+	export let endStyles: Array<EndStyle> = [null, null];
 	/**
 	 * @default 'false'
 	 * @description When `true`, the default Anchor will not be rendered. It is not necessary to set this to true
@@ -346,6 +355,8 @@
 
 		if (disconnect) edgeConfig.disconnect = true;
 		if (edgeStyle) edgeConfig.type = edgeStyle;
+		if (endStyles[0]) edgeConfig.start = endStyles[0];
+		if (endStyles[1]) edgeConfig.start = endStyles[1];
 		// Create a temporary edge to track the cursor
 		const newEdge = createEdge({ source, target }, source?.edge || null, edgeConfig);
 		// Add the edge to the store
@@ -403,6 +414,8 @@
 		};
 
 		if (edgeStyle) edgeConfig.type = edgeStyle;
+		if (endStyles[0]) edgeConfig.start = endStyles[0];
+		if (endStyles[1]) edgeConfig.start = endStyles[1];
 		const newEdge = createEdge({ source, target }, source?.edge || null, edgeConfig);
 		if (!source.node || !target.node) return false;
 		edgeStore.add(newEdge, new Set([source, target, source.node, target.node]));

--- a/src/lib/components/Edge/Edge.svelte
+++ b/src/lib/components/Edge/Edge.svelte
@@ -308,7 +308,7 @@
 	<svg class="edges-wrapper" style:z-index={zIndex} bind:this={edgeElement}>
 		<defs>
 			<marker
-				id="end-arrow"
+				id={edgeKey + '-end-arrow'}
 				viewBox="0 0 15 15"
 				markerWidth="15"
 				markerHeight="10"
@@ -319,7 +319,7 @@
 				<polygon class="arrow" points="0 0, 15 5, 0 10" style:--prop-edge-color={finalColor} />
 			</marker>
 			<marker
-				id="start-arrow"
+				id={edgeKey + '-start-arrow'}
 				viewBox="0 0 15 15"
 				markerWidth="15"
 				markerHeight="10"
@@ -350,8 +350,8 @@
 				class:animate
 				d={path}
 				style:--prop-edge-color={finalColor}
-				marker-end={end === 'arrow' ? 'url(#end-arrow)' : ''}
-				marker-start={start === 'arrow' ? 'url(#start-arrow)' : ''}
+				marker-end={end === 'arrow' ? `url(#${edgeKey + '-end-arrow'})` : ''}
+				marker-start={start === 'arrow' ? `url(#${edgeKey + '-start-arrow'})` : ''}
 				style:--prop-stroke-width={width ? width + 'px' : null}
 			/>
 		</slot>

--- a/src/lib/components/Edge/Edge.svelte
+++ b/src/lib/components/Edge/Edge.svelte
@@ -5,7 +5,7 @@
 	import { buildPath, rotateVector } from '$lib/utils/helpers';
 	import { buildArcStringKey, constructArcString } from '$lib/utils/helpers';
 	import { get } from 'svelte/store';
-	import type { CSSColorString, Direction, EdgeStyle, Graph } from '$lib/types';
+	import type { CSSColorString, Direction, EdgeStyle, EndStyle, Graph } from '$lib/types';
 	import type { WritableEdge } from '$lib/types';
 
 	let animationFrameId: number;
@@ -26,6 +26,7 @@
 <script lang="ts">
 	const edgeStore = getContext<Graph['edges']>('edgeStore');
 	const edgeStyle = getContext<EdgeStyle>('edgeStyle');
+	const endStyles = getContext<Array<EndStyle>>('endStyles');
 	const raiseEdgesOnSelect = getContext('raiseEdgesOnSelect');
 	const edgesAboveNode = getContext('edgesAboveNode');
 
@@ -33,6 +34,8 @@
 	export let edge: WritableEdge = getContext<WritableEdge>('edge');
 	export let straight = edgeStyle === 'straight';
 	export let step = edgeStyle === 'step';
+	export let start = endStyles[0];
+	export let end = endStyles[1];
 	export let animate = false;
 	export let label = '';
 	export let enableHover = false;
@@ -303,6 +306,20 @@
 
 {#if source && target}
 	<svg class="edges-wrapper" style:z-index={zIndex} bind:this={edgeElement}>
+		<!-- store arrows in defs -->
+		<defs>
+			<marker
+				id="end-arrow"
+				viewBox="0 0 15 15"
+				markerWidth="15"
+				markerHeight="10"
+				refX="12.5"
+				refY="5"
+				orient="auto"
+			>
+				<polygon class="arrow" points="0 0, 15 5, 0 10" style:--prop-edge-color={finalColor} />
+			</marker>
+		</defs>
 		<path
 			role="presentation"
 			id={edgeKey + '-target'}
@@ -317,11 +334,14 @@
 			bind:this={DOMPath}
 		/>
 		<slot {path} {destroy} {hovering}>
+			<!-- add marker-end -->
 			<path
 				id={edgeKey}
 				class="edge"
 				class:animate
 				d={path}
+				marker-end={end === 'arrow' ? 'url(#end-arrow)' : ''}
+				marker-start={start === 'arrow' ? 'url(#end-arrow)' : ''}
 				style:--prop-edge-color={finalColor}
 				style:--prop-stroke-width={width ? width + 'px' : null}
 			/>
@@ -346,6 +366,10 @@
 {/if}
 
 <style>
+	.arrow {
+		fill: var(--prop-edge-color, var(--edge-color, var(--default-edge-color)));
+	}
+
 	.edge {
 		stroke: var(--prop-edge-color, var(--edge-color, var(--default-edge-color)));
 		stroke-width: var(--prop-stroke-width, var(--edge-width, var(--default-edge-width)));

--- a/src/lib/components/Edge/Edge.svelte
+++ b/src/lib/components/Edge/Edge.svelte
@@ -306,30 +306,32 @@
 
 {#if source && target}
 	<svg class="edges-wrapper" style:z-index={zIndex} bind:this={edgeElement}>
-		<defs>
-			<marker
-				id={edgeKey + '-end-arrow'}
-				viewBox="0 0 15 15"
-				markerWidth="15"
-				markerHeight="10"
-				refX="12.5"
-				refY="5"
-				orient="auto"
-			>
-				<polygon class="arrow" points="0 0, 15 5, 0 10" style:--prop-edge-color={finalColor} />
-			</marker>
-			<marker
-				id={edgeKey + '-start-arrow'}
-				viewBox="0 0 15 15"
-				markerWidth="15"
-				markerHeight="10"
-				refX="0"
-				refY="5"
-				orient="auto"
-			>
-				<polygon class="arrow" points="0 5, 15 0, 15 10" style:--prop-edge-color={finalColor} />
-			</marker>
-		</defs>
+		{#if start || end}
+			<defs>
+				<marker
+					id={edgeKey + '-end-arrow'}
+					viewBox="0 0 15 15"
+					markerWidth="15"
+					markerHeight="10"
+					refX="12.5"
+					refY="5"
+					orient="auto"
+				>
+					<polygon class="arrow" points="0 0, 15 5, 0 10" style:--prop-edge-color={finalColor} />
+				</marker>
+				<marker
+					id={edgeKey + '-start-arrow'}
+					viewBox="0 0 15 15"
+					markerWidth="15"
+					markerHeight="10"
+					refX="0"
+					refY="5"
+					orient="auto"
+				>
+					<polygon class="arrow" points="0 5, 15 0, 15 10" style:--prop-edge-color={finalColor} />
+				</marker>
+			</defs>
+		{/if}
 		<path
 			role="presentation"
 			id={edgeKey + '-target'}

--- a/src/lib/components/Edge/Edge.svelte
+++ b/src/lib/components/Edge/Edge.svelte
@@ -306,7 +306,6 @@
 
 {#if source && target}
 	<svg class="edges-wrapper" style:z-index={zIndex} bind:this={edgeElement}>
-		<!-- store arrows in defs -->
 		<defs>
 			<marker
 				id="end-arrow"
@@ -318,6 +317,17 @@
 				orient="auto"
 			>
 				<polygon class="arrow" points="0 0, 15 5, 0 10" style:--prop-edge-color={finalColor} />
+			</marker>
+			<marker
+				id="start-arrow"
+				viewBox="0 0 15 15"
+				markerWidth="15"
+				markerHeight="10"
+				refX="0"
+				refY="5"
+				orient="auto"
+			>
+				<polygon class="arrow" points="0 5, 15 0, 15 10" style:--prop-edge-color={finalColor} />
 			</marker>
 		</defs>
 		<path
@@ -334,15 +344,14 @@
 			bind:this={DOMPath}
 		/>
 		<slot {path} {destroy} {hovering}>
-			<!-- add marker-end -->
 			<path
 				id={edgeKey}
 				class="edge"
 				class:animate
 				d={path}
-				marker-end={end === 'arrow' ? 'url(#end-arrow)' : ''}
-				marker-start={start === 'arrow' ? 'url(#end-arrow)' : ''}
 				style:--prop-edge-color={finalColor}
+				marker-end={end === 'arrow' ? 'url(#end-arrow)' : ''}
+				marker-start={start === 'arrow' ? 'url(#start-arrow)' : ''}
 				style:--prop-stroke-width={width ? width + 'px' : null}
 			/>
 		</slot>
@@ -367,7 +376,7 @@
 
 <style>
 	.arrow {
-		fill: var(--prop-edge-color, var(--edge-color, var(--default-edge-color)));
+		fill: var(--prop-edge-color, var(--edge-color, var(--default-edge-color))) !important;
 	}
 
 	.edge {

--- a/src/lib/components/Node/InternalNode.svelte
+++ b/src/lib/components/Node/InternalNode.svelte
@@ -141,7 +141,6 @@
 		if ($zIndex !== $maxZIndex && $zIndex !== Infinity) $zIndex = ++$maxZIndex;
 
 		const targetElement = e.target as HTMLElement; // Cast e.target to HTMLElement
-
 		if (tagsToIgnore.has(targetElement.tagName)) return;
 
 		e.preventDefault();

--- a/src/lib/components/data/Toggle/Toggle.svelte
+++ b/src/lib/components/data/Toggle/Toggle.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import type { CustomWritable } from '$lib/types';
+
+	export let parameterStore: CustomWritable<boolean>;
+
+	const handleKeyToggle = (event: KeyboardEvent) => {
+		event.stopPropagation();
+		if (event.key === 'Enter') {
+			$parameterStore = !$parameterStore;
+		}
+	};
+	const handleClickToggle = (event: MouseEvent) => {
+		event.stopPropagation();
+		$parameterStore = !$parameterStore;
+	};
+</script>
+
+<div
+	class="toggle-wrapper"
+	role="switch"
+	on:keydown|stopPropagation={handleKeyToggle}
+	tabindex={0}
+	aria-checked={$parameterStore}
+	aria-label="Toggle Switch"
+>
+	<label class="switch">
+		<input
+			type="checkbox"
+			on:click|stopPropagation={handleClickToggle}
+			bind:checked={$parameterStore}
+		/>
+		<span class="slider round" />
+	</label>
+</div>
+
+<style>
+	.switch {
+		position: relative;
+		display: inline-block;
+		width: 60px;
+		height: 34px;
+		cursor: pointer;
+	}
+
+	.switch input {
+		opacity: 0;
+		width: 60px;
+		height: 30px;
+		cursor: pointer;
+	}
+
+	.slider {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background-color: #ccc;
+		-webkit-transition: 0.4s;
+		transition: 0.4s;
+	}
+
+	.slider:before {
+		position: absolute;
+		content: '';
+		height: 26px;
+		width: 26px;
+		left: 4px;
+		bottom: 4px;
+		background-color: white;
+		-webkit-transition: 0.4s;
+		transition: 0.4s;
+	}
+
+	input:checked + .slider {
+		background-color: #2196f3;
+	}
+
+	input:focus + .slider {
+		box-shadow: 0 0 1px #2196f3;
+	}
+
+	input:checked + .slider:before {
+		-webkit-transform: translateX(26px);
+		-ms-transform: translateX(26px);
+		transform: translateX(26px);
+	}
+
+	.slider.round {
+		border-radius: 34px;
+		pointer-events: none;
+	}
+
+	.slider.round:before {
+		border-radius: 50%;
+	}
+</style>

--- a/src/lib/containers/Svelvet/Svelvet.svelte
+++ b/src/lib/containers/Svelvet/Svelvet.svelte
@@ -6,7 +6,13 @@
 	import { graphStore } from '$lib/stores';
 	import { reloadStore } from '$lib/utils/savers/reloadStore';
 	import type { ComponentType } from 'svelte';
-	import type { Graph as GraphType, EdgeStyle, XYPair, SvelvetConnectionEvent } from '$lib/types';
+	import type {
+		Graph as GraphType,
+		EdgeStyle,
+		EndStyle,
+		XYPair,
+		SvelvetConnectionEvent
+	} from '$lib/types';
 	import type { NodeConfig, GraphKey, CSSColorString, NodeKey } from '$lib/types';
 	import type { Node, Anchor } from '$lib/types';
 </script>
@@ -52,6 +58,7 @@
 	 */
 	export let selectionColor: CSSColorString = 'lightblue';
 	export let edgeStyle: EdgeStyle = 'bezier';
+	export let endStyles: Array<EndStyle> = [null, null];
 	export let edge: ComponentType | null = null;
 	/**
 	 * @default false
@@ -103,6 +110,7 @@
 
 	setContext('snapTo', snapTo);
 	setContext('edgeStyle', edgeStyle);
+	setContext('endStyles', endStyles);
 	setContext('graphEdge', edge);
 	setContext('raiseEdgesOnSelect', raiseEdgesOnSelect);
 	setContext('edgesAboveNode', edgesAboveNode);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,6 +8,7 @@ import Group from './components/Group/Group.svelte';
 import Knob from './components/data/Knob/Knob.svelte';
 import Drawer from './components/Drawer/Drawer.svelte';
 import Slider from './components/data/Slider/Slider.svelte';
+import Toggle from './components/data/Toggle/Toggle.svelte';
 import RadioGroup from './components/data/RadioGroup/RadioGroup.svelte';
 import Background from './containers/Background/Background.svelte';
 import ThemeToggle from './components/ThemeToggle/ThemeToggle.svelte';
@@ -26,6 +27,7 @@ export {
 	Group,
 	Resizer,
 	Slider,
+	Toggle,
 	Knob,
 	RadioGroup,
 	ThemeToggle,

--- a/src/lib/types/edge.ts
+++ b/src/lib/types/edge.ts
@@ -12,6 +12,7 @@ import type {
 import type { PixelValue, RemValue } from '.';
 import type { ComponentType } from 'svelte';
 export type EdgeStyle = 'straight' | 'step' | 'bezier';
+export type EndStyle = 'arrow' | null;
 
 // With writable properties
 export type WritableEdge = {
@@ -31,6 +32,8 @@ export type WritableEdge = {
 	rendered: Writable<boolean>;
 	// raiseEdgeOnSelect?: boolean;
 	// edgesAbove?: boolean;
+	start: EndStyle;
+	end: EndStyle;
 };
 
 interface CursorNode {
@@ -86,6 +89,8 @@ export interface EdgeConfig {
 	disconnect?: true;
 	raiseEdges?: boolean;
 	edgesAbove?: boolean;
+	start?: EndStyle;
+	end?: EndStyle;
 }
 
 export interface EdgeLabelConfig {

--- a/src/routes/arrows/+page.svelte
+++ b/src/routes/arrows/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { Svelvet, Node, Anchor, Edge } from '$lib';
 	import ArrowEdge from './ArrowEdge.svelte';
+	import ArrowEdgeBlue from './ArrowEdgeBlue.svelte';
 </script>
 
-<Svelvet minimap controls theme={'dark'} width={1200} height={800}>
+<Svelvet minimap controls theme={'dark'} width={1200} height={800} endStyles={[null, 'arrow']}>
 	<Node
 		position={{ x: 100, y: 200 }}
 		dimensions={{ width: 100, height: 100 }}
@@ -12,4 +13,20 @@
 		edge={ArrowEdge}
 	/>
 	<Node position={{ x: 100, y: 500 }} dimensions={{ width: 100, height: 100 }} TD label={'TD-IN'} />
+	<Node
+		position={{ x: 400, y: 200 }}
+		dimensions={{ width: 100, height: 100 }}
+		TD
+		label={'TD-OUT-B'}
+		edge={ArrowEdgeBlue}
+	/>
+	<Node
+		position={{ x: 400, y: 500 }}
+		dimensions={{ width: 100, height: 100 }}
+		TD
+		label={'TD-IN-B'}
+	/>
+	<Node position={{ x: 200, y: 100 }} dimensions={{ width: 100, height: 100 }} useDefaults>
+		<Anchor output />
+	</Node>
 </Svelvet>

--- a/src/routes/arrows/+page.svelte
+++ b/src/routes/arrows/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { Svelvet, Node, Anchor, Edge } from '$lib';
+	import ArrowEdge from './ArrowEdge.svelte';
+</script>
+
+<Svelvet minimap controls theme={'dark'} width={1200} height={800}>
+	<Node
+		position={{ x: 100, y: 200 }}
+		dimensions={{ width: 100, height: 100 }}
+		TD
+		label={'TD-OUT'}
+		edge={ArrowEdge}
+	/>
+	<Node position={{ x: 100, y: 500 }} dimensions={{ width: 100, height: 100 }} TD label={'TD-IN'} />
+</Svelvet>

--- a/src/routes/arrows/ArrowEdge.svelte
+++ b/src/routes/arrows/ArrowEdge.svelte
@@ -2,4 +2,14 @@
 	import { Edge } from '$lib';
 </script>
 
-<Edge let:path end="arrow" color="red" width={3} />
+<Edge
+	let:path
+	end="arrow"
+	start="arrow"
+	color="red"
+	step={true}
+	width={3}
+	animate={true}
+	label="red"
+	labelColor="red"
+/>

--- a/src/routes/arrows/ArrowEdge.svelte
+++ b/src/routes/arrows/ArrowEdge.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { Edge } from '$lib';
+</script>
+
+<Edge let:path end="arrow" color="red" width={3} />

--- a/src/routes/arrows/ArrowEdgeBlue.svelte
+++ b/src/routes/arrows/ArrowEdgeBlue.svelte
@@ -2,4 +2,4 @@
 	import { Edge } from '$lib';
 </script>
 
-<Edge let:path end="arrow" start="arrow" color="blue" step={true} width={3} animate={true} />
+<Edge let:path start="arrow" end="arrow" color="blue" step={true} width={3} animate={true} />

--- a/src/routes/arrows/ArrowEdgeBlue.svelte
+++ b/src/routes/arrows/ArrowEdgeBlue.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { Edge } from '$lib';
+</script>
+
+<Edge let:path end="arrow" start="arrow" color="blue" step={true} width={3} animate={true} />

--- a/src/routes/toggle/+page.svelte
+++ b/src/routes/toggle/+page.svelte
@@ -17,11 +17,19 @@
 
 <Svelvet minimap controls theme={'dark'} width={800} height={500}>
 	<Node width={200} height={100} useDefaults position={{ x: 100, y: 200 }}>
+		<h2>Toggle</h2>
 		<Toggle parameterStore={$inputs.value} />
 		<Anchor outputStore={outputs} output />
 	</Node>
 
-	<Node id={'displayNode'} useDefaults width={200} height={100} position={{ x: 400, y: 200 }}>
+	<Node
+		id={'displayNode'}
+		useDefaults
+		width={200}
+		height={100}
+		position={{ x: 400, y: 200 }}
+		bgColor={$outputs ? 'blue' : 'red'}
+	>
 		<p id="output-num">{$outputs}</p>
 		<Anchor inputsStore={inputs} input direction={'west'} />
 	</Node>

--- a/src/routes/toggle/+page.svelte
+++ b/src/routes/toggle/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { Svelvet, Node, Toggle, Anchor } from '$lib';
+	import { generateInput, generateOutput } from '$lib';
+
+	type InputStructure = {
+		value: boolean;
+	};
+
+	const initialData = {
+		value: false
+	};
+
+	const inputs = generateInput(initialData);
+	const processor = (inputs: InputStructure) => inputs.value;
+	const outputs = generateOutput(inputs, processor);
+</script>
+
+<Svelvet minimap controls theme={'dark'} width={800} height={500}>
+	<Node width={200} height={100} useDefaults position={{ x: 100, y: 200 }}>
+		<Toggle parameterStore={$inputs.value} />
+		<Anchor outputStore={outputs} output />
+	</Node>
+
+	<Node id={'displayNode'} useDefaults width={200} height={100} position={{ x: 400, y: 200 }}>
+		<p id="output-num">{$outputs}</p>
+		<Anchor inputsStore={inputs} input direction={'west'} />
+	</Node>
+</Svelvet>

--- a/tests/e2e-tests/toggle/test.ts
+++ b/tests/e2e-tests/toggle/test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+const testRoute = '/toggle';
+
+test('toggle functionality transmits data', async ({ page }) => {
+	await page.goto(testRoute);
+
+	const input = page.locator('input');
+
+	const node = page.locator('#N-displayNode');
+
+	// toggle shows the default boolean, node should be red
+	await expect(node).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+
+	// can select and use toggle using keys, node switches to blue
+	await page.keyboard.press('Tab');
+	await page.keyboard.press('Tab');
+	await page.keyboard.press('Tab');
+	await page.keyboard.press('Enter');
+	await expect(node).toHaveCSS('background-color', 'rgb(0, 0, 255)');
+
+	// clicking the toggle switches the boolean, node switches to red
+	await input.click();
+	await expect(node).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+});


### PR DESCRIPTION
Adds the ability to add arrows on to the start and end of edges via start and end props on edges or endStyles prop on Svelvet. Also adds new Toggle data flow components that can be used to pass a boolean and toggle between true and false and the tests that go with it.