### PR TITLE
doc fix for svelvet and styling

### DIFF
--- a/docs/components/svelvet.mdx
+++ b/docs/components/svelvet.mdx
@@ -49,7 +49,7 @@ Svelvet is the wrapping parent component that renders out nodes and edges. It is
 <ResponseField name="edgeStyle" type="bezier | step | straight" default="bezier">
 	Enum representing the global edge style for the canvas. Overriden when passing custom Edges.
 </ResponseField>
-<ResponseField name="endStyles" type="["arrow" | null , "arrow" | null]" default="[null , null]">
+<ResponseField name="endStyles" type="['arrow' | null , 'arrow' | null]" default="[null , null]">
 	Enum representing the global end styles for the canvas. First element in array will be applied to the start of the edge, second element in array will be applied to the end of the edge. Overriden when passing custom Edges.
 </ResponseField>
 <ResponseField name="snapTo" type="number" default="1">

--- a/docs/styling.mdx
+++ b/docs/styling.mdx
@@ -66,7 +66,7 @@ Scroll to the bottom for example code.
 </ResponseField>
 
 <ResponseField name="--node-color" default="white">
-	Shadow of the default Node
+	Color of the default Node
 </ResponseField>
 
 <ResponseField name="--node-text-color" default="white">


### PR DESCRIPTION
Fixed a clerical error in styles where they used the same description for multiple props. Also fixed an issue where Svelvet Component docs wouldn't render.